### PR TITLE
Patch to work with freedesktop 18.08

### DIFF
--- a/com.sublimetext.three.json
+++ b/com.sublimetext.three.json
@@ -1,11 +1,11 @@
 {
     "app-id": "com.sublimetext.three",
     "runtime": "org.freedesktop.Sdk",
-    "runtime-version": "unstable",
+    "runtime-version": "18.08",
     "sdk": "org.freedesktop.Sdk",
     "base": "io.atom.electron.BaseApp",
-    "base-version": "stable",
-    "branch": "stable",
+    "base-version": "18.08",
+    "branch": "18.08",
     "command": "sublime",
     "separate-locales": false,
     "finish-args": [

--- a/com.sublimetext.three.json
+++ b/com.sublimetext.three.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.sublimetext.three",
     "runtime": "org.freedesktop.Sdk",
-    "runtime-version": "1.6",
+    "runtime-version": "unstable",
     "sdk": "org.freedesktop.Sdk",
     "base": "io.atom.electron.BaseApp",
     "base-version": "stable",
@@ -106,7 +106,7 @@
                 "install -Dm644 com.sublimetext.three-64.png /app/share/icons/hicolor/64x64/apps/com.sublimetext.three.png",
                 "install -Dm644 com.sublimetext.three-128.png /app/share/icons/hicolor/128x128/apps/com.sublimetext.three.png",
                 "cp /usr/bin/ar /app/bin",
-                "cp /usr/lib/libbfd-*.so /app/lib"
+                "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so /app/lib"
             ],
             "post-install": [
                 "mkdir -p /app/etc/xdg",


### PR DESCRIPTION
Freedesktop 18.08 works with multi-arch, so libraries are split out,
and libbfd has moved. This patch updates the copying of libbfd to
the new multi-arch system.

Obviously don't merge until freedesktop released as stable

Note: This is not backwards compatible with 1.6 as /usr/lib/{multiarch-triple}/libbfd.so doesn't exist in 1.6