### PR TITLE
Enable wayland and dri

### DIFF
--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -10,8 +10,11 @@ sdk: org.freedesktop.Sdk
 separate-locales: false
 finish-args:
   - --share=ipc
-  - --socket=x11
   - --share=network
+  - --device=dri
+  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=wayland
   - --talk-name=org.gnome.SettingsDaemon
   - --filesystem=host
 


### PR DESCRIPTION
Expose wayland if available, otherwise fall back to X11.

Expose DRI for hardware accelerated rendering.