### PR TITLE
Some improvements

### DIFF
--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -1,7 +1,6 @@
 ---
 app-id: com.sublimetext.three
-branch: stable
-command: sublime
+command: subl
 
 runtime: org.freedesktop.Sdk
 runtime-version: "18.08"
@@ -17,6 +16,7 @@ finish-args:
   - --socket=wayland
   - --talk-name=org.gnome.SettingsDaemon
   - --filesystem=host
+  - --env=PATH=/app/utils/bin:/app/sublime_merge/bin:/app/bin:/usr/bin
 
 add-extensions:
   com.sublimetext.three.DevUtils:
@@ -34,18 +34,22 @@ modules:
       - type: script
         dest-filename: apply_extra
         commands:
-          - ar x sublime.deb
-          - rm -f sublime.deb
-          - tar xf data.tar.xz
-          - rm -f control.tar.xz data.tar.xz debian-binary
-          - mv usr/* .
-          - rmdir usr
-          - mkdir -p export/share/applications
-          - sed s/Icon=sublime-text/Icon=com.sublimetext.three/ share/applications/sublime_text.desktop > export/share/applications/com.sublimetext.three.desktop
-          - sed -i 's:Exec=/opt/sublime_text/sublime_text:Exec=sublime:' export/share/applications/com.sublimetext.three.desktop
-          - mkdir -p export/share/icons/hicolor/256x256/apps
-          - cp share/icons/hicolor/256x256/apps/sublime-text.png export/share/icons/hicolor/256x256/apps/com.sublimetext.three.png
-          - sed -i 's:/opt/sublime_text/sublime_text:/app/extra/opt/sublime_text/sublime_text:' /app/extra/bin/subl
+          - FLATPAK_ID=com.sublimetext.three
+          # Extract upstream package
+          - mkdir -p deb-package export/share
+          - ar p sublime.deb data.tar.xz | tar -xJf - -C deb-package
+          # Install desktop entry and icons
+          - mv deb-package/usr/share/{applications,icons} export/share/
+          - rename sublime_text ${FLATPAK_ID} export/share/applications/*.desktop
+          - rename sublime-text ${FLATPAK_ID} export/share/icons/hicolor/*/apps/*
+          - desktop-file-edit
+            --set-key=Exec --set-value=subl
+            --set-key=Icon --set-value=${FLATPAK_ID}
+            export/share/applications/${FLATPAK_ID}.desktop
+          # Install the app
+          - mv deb-package/opt/sublime_text ./
+          # Cleanup
+          - rm -rf deb-package sublime.deb
       - type: script
         dest-filename: sublime.sh
         commands:
@@ -54,10 +58,8 @@ modules:
           - if ! test -f "$PCLOCATION/$PCFILE"; then
           -     cp "/app/extra/$PCFILE" "$PCLOCATION"
           - fi
-          - export PATH=/app/utils/bin:$PATH
-          - export PYTHONPATH=/app/utils/lib/python3.5/site-packages:$PYTHONPATH
           - export LC_NUMERIC=C
-          - exec /app/extra/bin/subl "$@"
+          - exec /app/extra/sublime_text/sublime_text --fwdargv0 "$0" "$@"
       - type: extra-data
         only-arches: ["x86_64"]
         filename: sublime.deb
@@ -85,7 +87,7 @@ modules:
       - mkdir -p /app/bin
       - mkdir -p /app/lib
       - install apply_extra /app/bin
-      - install sublime.sh /app/bin/sublime
+      - install sublime.sh /app/bin/subl
       - install -Dm644 com.sublimetext.three.appdata.xml /app/share/appdata/com.sublimetext.three.appdata.xml
       - install -Dm644 com.sublimetext.three-64.png /app/share/icons/hicolor/64x64/apps/com.sublimetext.three.png
       - install -Dm644 com.sublimetext.three-128.png /app/share/icons/hicolor/128x128/apps/com.sublimetext.three.png

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -61,10 +61,11 @@ modules:
         commands:
           - PCFILE="Package Control.sublime-package"
           - PCLOCATION="$HOME/.var/app/com.sublimetext.three/config/sublime-text-3/Installed Packages"
-          - if ! test -f "$PCLOCATION/$PCFILE"; then
+          - |
+            if ! test -f "$PCLOCATION/$PCFILE"; then
                 mkdir -p "$PCLOCATION"
-          -     cp "/app/extra/$PCFILE" "$PCLOCATION"
-          - fi
+                cp "/app/extra/$PCFILE" "$PCLOCATION"
+            fi
           - export LC_NUMERIC=C
           - exec /app/extra/sublime_text/sublime_text --fwdargv0 "$0" "$@"
       - type: extra-data

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -19,6 +19,10 @@ finish-args:
   - --env=PATH=/app/utils/bin:/app/sublime_merge/bin:/app/bin:/usr/bin
 
 add-extensions:
+  com.sublimetext.three.SublimeMerge:
+    directory: sublime_merge
+    add-ld-path: lib
+
   com.sublimetext.three.DevUtils:
     version: "19.08"
     directory: utils
@@ -48,6 +52,7 @@ modules:
             export/share/applications/${FLATPAK_ID}.desktop
           # Install the app
           - mv deb-package/opt/sublime_text ./
+          - ln -sr /app/sublime_merge/extra/sublime_merge ./sublime_merge
           # Cleanup
           - rm -rf deb-package sublime.deb
       - type: script
@@ -92,5 +97,6 @@ modules:
       - install -Dm644 com.sublimetext.three-64.png /app/share/icons/hicolor/64x64/apps/com.sublimetext.three.png
       - install -Dm644 com.sublimetext.three-128.png /app/share/icons/hicolor/128x128/apps/com.sublimetext.three.png
     post-install:
-      # This creates the mount point for the DevUtils extension.
+      # This creates the mount point for the extensions.
       - mkdir -p /app/utils
+      - mkdir -p /app/sublime_merge

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -17,6 +17,7 @@ finish-args:
   - --talk-name=org.gnome.SettingsDaemon
   - --filesystem=host
   - --env=PATH=/app/utils/bin:/app/sublime_merge/bin:/app/bin:/usr/bin
+  - --env=PYTHONPATH=/app/utils/lib/python3.7/site-packages
 
 add-extensions:
   com.sublimetext.three.SublimeMerge:

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -3,7 +3,7 @@ app-id: com.sublimetext.three
 command: subl
 
 runtime: org.freedesktop.Sdk
-runtime-version: "18.08"
+runtime-version: "19.08"
 sdk: org.freedesktop.Sdk
 
 separate-locales: false
@@ -20,7 +20,7 @@ finish-args:
 
 add-extensions:
   com.sublimetext.three.DevUtils:
-    version: "18.08"
+    version: "19.08"
     directory: utils
     subdirectories: false
     add-ld-path: lib

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -57,7 +57,7 @@ modules:
           # Cleanup
           - rm -rf deb-package sublime.deb
       - type: script
-        dest-filename: sublime.sh
+        dest-filename: subl
         commands:
           - PCFILE="Package Control.sublime-package"
           - PCLOCATION="$HOME/.var/app/com.sublimetext.three/config/sublime-text-3/Installed Packages"
@@ -94,7 +94,7 @@ modules:
       - mkdir -p /app/bin
       - mkdir -p /app/lib
       - install apply_extra /app/bin
-      - install sublime.sh /app/bin/subl
+      - install subl /app/bin/subl
       - install -Dm644 com.sublimetext.three.appdata.xml /app/share/appdata/com.sublimetext.three.appdata.xml
       - install -Dm644 com.sublimetext.three-64.png /app/share/icons/hicolor/64x64/apps/com.sublimetext.three.png
       - install -Dm644 com.sublimetext.three-128.png /app/share/icons/hicolor/128x128/apps/com.sublimetext.three.png

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -62,6 +62,7 @@ modules:
           - PCFILE="Package Control.sublime-package"
           - PCLOCATION="$HOME/.var/app/com.sublimetext.three/config/sublime-text-3/Installed Packages"
           - if ! test -f "$PCLOCATION/$PCFILE"; then
+                mkdir -p "$PCLOCATION"
           -     cp "/app/extra/$PCFILE" "$PCLOCATION"
           - fi
           - export LC_NUMERIC=C


### PR DESCRIPTION
- Update runtime to 19.08
- Add extension point for Sublime Merge
- Slightly rework apply_extra script
  - Extract upstream package in one run
  - Install all icons
  - Use `rename` utility for renames
  - Use `desktop-file-edit` utility to alter keys in .desktop file
- Run `sublime_text` binary directly from the wrapper, dropping upstream script
- Remove branch, `stable` is default
- Set `PATH` and `PYTHONPATH` via `finish-args`

Some of this changes might be subjective, so it's ok to reject it if you disagree.