### PR TITLE
Fix package control having incorrect size and shasum

### DIFF
--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -83,8 +83,8 @@ modules:
       - type: extra-data
         filename: Package Control.sublime-package
         url: http://packagecontrol.io/Package%20Control.sublime-package
-        sha256: 6f4c264a24d933ce70df5dedcf1dcaeeebe013ee18cced0ef93d5f746d80ef60
-        size: 286331
+        sha256: 817937144c34c84c88cd43b85318b2656f9c3fac02f8f72cbc18360b2c26d139
+        size: 471460
       - type: file
         path: com.sublimetext.three.desktop
       - type: file


### PR DESCRIPTION
While I'm aware of that this might not be the ideal solution in the long term, I think having the package work while a better solution is figured out is a good idea.

Fixes https://github.com/flathub/com.sublimetext.three/issues/20