### PR TITLE
Preparing the end for the Sublime Text 3 flatpak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.flatpak-builder
+/repo

--- a/com.sublimetext.three.appdata.xml
+++ b/com.sublimetext.three.appdata.xml
@@ -12,9 +12,8 @@
   <url type="help">https://forum.sublimetext.com/</url>
   <launchable type="desktop-id">com.sublimetext.three.desktop</launchable>
   <description>
-    <p>A sophisticated text editor for code, markup and prose.</p>
-    <p>Sublime Text is a super fast and feature packed text and development editor. It supports many programming and markup languages, and functions as a powerful IDE for many of them. You'll love the slick user interface, extraordinary features and amazing performance.</p>
-    <p>NOTE: THIS VERSION OF SUBLIME TEXT IS OUTDATED. WORK IS ONGOING TO PACKAGE SUBLIME TEXT 4 FOR FLATHUB.</p>
+    <p>*Note*: This is Sublime Text 3. Sublime Text 4 is not yet available on Flathub. This has been packaged into a flatpak by the community and is not yet supported by Sublime HQ.</p>
+    <p>Sublime Text is a text editor with a clean and aesthetic interface. It also stands out for its many features and the large number of supported programming languages.</p>
   </description>
   <screenshots>
     <screenshot type="default">

--- a/com.sublimetext.three.appdata.xml
+++ b/com.sublimetext.three.appdata.xml
@@ -5,14 +5,17 @@
   <name>Sublime Text 3</name>
   <project_license>LicenseRef-proprietary=https://www.sublimetext.com/eula</project_license>
   <developer_name>Sublime HQ Pty Ltd</developer_name>
-  <summary>(Outdated) Sophisticated text editor for code, markup and prose</summary>
+  <summary>Sophisticated text editor for code, markup and prose</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <url type="homepage">https://www.sublimetext.com/</url>
   <url type="bugtracker">https://github.com/SublimeTextIssues/Core/issues</url>
   <url type="help">https://forum.sublimetext.com/</url>
   <launchable type="desktop-id">com.sublimetext.three.desktop</launchable>
   <description>
-    <p>(Outdated) A sophisticated text editor for code, markup and prose.</p>
+    <p>A sophisticated text editor for code, markup and prose.</p>
+    <p>Sublime Text is a super fast and feature packed text and development editor. It supports many programming and markup languages, and functions as a powerful IDE for many of them. You'll love the slick user interface, extraordinary features and amazing performance.</p>
+    <p></p>
+    <p>NOTE : THIS VERSION OF SUBLIME TEXT IS OUTDATED. WORK IS ONGOING TO PACKAGE SUBLIME TEXT 4 FOR FLATHUB.</p>
   </description>
   <screenshots>
     <screenshot type="default">

--- a/com.sublimetext.three.appdata.xml
+++ b/com.sublimetext.three.appdata.xml
@@ -18,7 +18,8 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source" caption="Screenshot of Sublime Text 3 with a project opened" >https://www.sublimetext.com/screenshots/3.0/linux.png</image>
+      <caption>Screenshot of Sublime Text 3 with a project opened</caption>
+      <image type="source">https://www.sublimetext.com/screenshots/3.0/linux.png</image>
     </screenshot>
   </screenshots>
   <categories>

--- a/com.sublimetext.three.appdata.xml
+++ b/com.sublimetext.three.appdata.xml
@@ -8,17 +8,17 @@
   <summary>Sophisticated text editor for code, markup and prose</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <url type="homepage">https://www.sublimetext.com/</url>
-  <url type="bugtracker">https://github.com/SublimeTextIssues/Core/issues</url>
+  <url type="bugtracker">https://github.com/flathub/com.sublimetext.three/issues</url>
   <url type="help">https://forum.sublimetext.com/</url>
   <launchable type="desktop-id">com.sublimetext.three.desktop</launchable>
   <description>
     <p>A sophisticated text editor for code, markup and prose.</p>
     <p>Sublime Text is a super fast and feature packed text and development editor. It supports many programming and markup languages, and functions as a powerful IDE for many of them. You'll love the slick user interface, extraordinary features and amazing performance.</p>
-    <p>NOTE : THIS VERSION OF SUBLIME TEXT IS OUTDATED. WORK IS ONGOING TO PACKAGE SUBLIME TEXT 4 FOR FLATHUB.</p>
+    <p>NOTE: THIS VERSION OF SUBLIME TEXT IS OUTDATED. WORK IS ONGOING TO PACKAGE SUBLIME TEXT 4 FOR FLATHUB.</p>
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://www.sublimetext.com/screenshots/3.0/linux.png</image>
+      <image type="source" caption="Screenshot of Sublime Text 3 with a project opened" >https://www.sublimetext.com/screenshots/3.0/linux.png</image>
     </screenshot>
   </screenshots>
   <categories>

--- a/com.sublimetext.three.appdata.xml
+++ b/com.sublimetext.three.appdata.xml
@@ -2,17 +2,17 @@
 <!-- Copyright 2018 Endless Mobile, Inc. -->
 <component type="desktop">
   <id>com.sublimetext.three</id>
-  <name>Sublime Text</name>
+  <name>Sublime Text 3</name>
   <project_license>LicenseRef-proprietary=https://www.sublimetext.com/eula</project_license>
   <developer_name>Sublime HQ Pty Ltd</developer_name>
-  <summary>Sophisticated text editor for code, markup and prose</summary>
+  <summary>(Outdated) Sophisticated text editor for code, markup and prose</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <url type="homepage">https://www.sublimetext.com/</url>
   <url type="bugtracker">https://github.com/SublimeTextIssues/Core/issues</url>
   <url type="help">https://forum.sublimetext.com/</url>
   <launchable type="desktop-id">com.sublimetext.three.desktop</launchable>
   <description>
-    <p>A sophisticated text editor for code, markup and prose.</p>
+    <p>(Outdated) A sophisticated text editor for code, markup and prose.</p>
   </description>
   <screenshots>
     <screenshot type="default">
@@ -27,8 +27,41 @@
   <icon type="remote" height="128" width="128">https://raw.githubusercontent.com/flathub/com.sublimetext.three/master/com.sublimetext.three-128.png</icon>
   <icon type="remote" height="64" width="64">https://raw.githubusercontent.com/flathub/com.sublimetext.three/master/com.sublimetext.three-64.png</icon>
   <releases>
-    <release date="2019-10-01" version="3.2.2" />
-    <release date="2019-04-06" version="3.2.1" />
+    <release date="2019-10-01" version="3.2.2">
+      <description>
+        <p>3.2.2 (Build 3211)</p>
+        <ul>
+          <li>Mac: Added Notarization</li>
+          <li>Fixed a performance regression when moving the caret upwards in large files</li>
+          <li>Fixed a memory leak</li>
+          <li>Fixed not being able to swap lines down with the last line if it was empty</li>
+          <li>Git: Fixed includeIf handling in git config files not interpreting ~ relative paths correctly</li>
+        </ul>
+      </description>
+    </release>
+    <release date="2019-04-06" version="3.2.1">
+      <description>
+        <p>3.2.1 (Build 3207)</p>
+        <ul>
+          <li>Various syntax highlighting improvements</li>
+          <li>Git: Git repositories at the top level of a users home directory are ignored for performance reasons. This can be changed via the allow_git_home_dir setting.</li>
+          <li>Git: Improved performance with a large number of git repositories in the side bar</li>
+          <li>Git: Fixed UTF8 BOMs not being handled correctly in .gitignore files</li>
+          <li>Fixed a crash in the Git repository handling</li>
+          <li>Improved file indexing behavior in some scenarios</li>
+          <li>Improved scrolling logic in some scenarios</li>
+          <li>Fixed block carets changing the way text selection works</li>
+          <li>Fixed swap_line_up and swap_line_down transforming tabs into spaces</li>
+          <li>Mac: Added a workaround for a MacOS issue with DisplayLink adapters</li>
+          <li>Linux: Fixed compatibility with old Linux distributions</li>
+          <li>Linux: Improved high dpi handling under KDE</li>
+          <li>Linux: Tweaked the way text scaling is handled</li>
+          <li>Linux: Fixed incorrect file ownership in the deb packages</li>
+          <li>API: Fixed an incompatibility with SublimeREPL</li>
+          <li>API: Fixed regression with phantoms interfering with home/end behavior</li>
+        </ul>
+      </description>
+    </release>
     <release date="2019-03-13" version="3.2">
       <description>
         <p>3.2 (BUILD 3200)</p>

--- a/com.sublimetext.three.appdata.xml
+++ b/com.sublimetext.three.appdata.xml
@@ -14,7 +14,6 @@
   <description>
     <p>A sophisticated text editor for code, markup and prose.</p>
     <p>Sublime Text is a super fast and feature packed text and development editor. It supports many programming and markup languages, and functions as a powerful IDE for many of them. You'll love the slick user interface, extraordinary features and amazing performance.</p>
-    <p></p>
     <p>NOTE : THIS VERSION OF SUBLIME TEXT IS OUTDATED. WORK IS ONGOING TO PACKAGE SUBLIME TEXT 4 FOR FLATHUB.</p>
   </description>
   <screenshots>
@@ -86,13 +85,7 @@
           <li>In coordination with the new Git functionality, diffs can be calculated against HEAD or the index</li>
           <li>The git_diff_target setting controls base document source</li>
           <li>API methods View.set_reference_document() and View.reset_reference_document() allow controlling the diff</li>
-          <li>The following diff-related commands were added:
-            <ul>
-              <li>Next Modification</li>
-              <li>Previous Modification</li>
-              <li>Revert Modification</li>
-            </ul>
-          </li>
+          <li>The following diff-related commands were added: `Next Modification`, `Previous Modification` and `Revert Modification`</li>
           <li>Full inline diffs of each change can be displayed via the right-click context menu, or keyboard shortcuts</li>
           <li>Inline diff presentation can be changed by customizing a color scheme</li>
         </ul>
@@ -107,13 +100,7 @@
         </ul>
         <p>Themes/UI</p>
         <ul>
-          <li>Enhanced the .sublime-theme format:
-            <ul>
-              <li>Added variables support and associated revised JSON format with variables key</li>
-              <li>Added extends keyword to have one theme derive from another</li>
-              <li>Colors may be specified via CSS syntax</li>
-            </ul>
-          </li>
+          <li>Enhanced the .sublime-theme format: Added variables support and associated revised JSON format with variables key; added extends keyword to have one theme derive from another; colors may be specified via CSS syntax.</li>
           <li>Improved performance with large numbers of rules in a .sublime-theme</li>
           <li>Moved to GTK3</li>
           <li>Various high DPI fixes</li>
@@ -133,14 +120,7 @@
         </ul>
         <p>Syntax Highlighting</p>
         <ul>
-          <li>Many syntax highlighting improvements, including significant improvements to:
-            <ul>
-              <li>Clojure, with thanks to Nelo Mitranim</li>
-              <li>D</li>
-              <li>Go, with thanks to Nelo Mitranim</li>
-              <li>Lua, with thanks to Thomas Smith</li>
-            </ul>
-          </li>
+          <li>Many syntax highlighting improvements, including significant improvements to Clojure (with thanks to Nelo Mitranim), D, Go (with thanks to Nelo Mitranim), and Lua (with thanks to Thomas Smith).</li>
           <li>Fixed a crash that could occur when nesting embed patterns in .sublime-syntax files</li>
           <li>Syntax Tests: Allow syntax test files to have a UTF-8 BOM</li>
         </ul>

--- a/com.sublimetext.three.desktop
+++ b/com.sublimetext.three.desktop
@@ -4,7 +4,6 @@ Type=Application
 Name=Sublime Text
 GenericName=Text Editor
 Comment=Sophisticated text editor for code, markup and prose
-Exec=/usr/bin/flatpak run --branch=master --arch=x86_64 --command=subl --file-forwarding com.sublimetext.three @@ %F @@
 Terminal=false
 MimeType=text/plain;
 Icon=com.sublimetext.three
@@ -16,10 +15,8 @@ X-Flatpak=com.sublimetext.three
 
 [Desktop Action Window]
 Name=New Window
-Exec=/usr/bin/flatpak run --branch=master --arch=x86_64 --command=/opt/sublime_text/sublime_text com.sublimetext.three -n
 OnlyShowIn=Unity;
 
 [Desktop Action Document]
 Name=New File
-Exec=/usr/bin/flatpak run --branch=master --arch=x86_64 --command=/opt/sublime_text/sublime_text com.sublimetext.three --command new_file
 OnlyShowIn=Unity;

--- a/com.sublimetext.three.desktop
+++ b/com.sublimetext.three.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=Sublime Text
+Name=Sublime Text 3
 GenericName=Text Editor
 Comment=Sophisticated text editor for code, markup and prose
 Exec=subl --file-forwarding com.sublimetext.three @@ %F @@

--- a/com.sublimetext.three.desktop
+++ b/com.sublimetext.three.desktop
@@ -4,6 +4,7 @@ Type=Application
 Name=Sublime Text
 GenericName=Text Editor
 Comment=Sophisticated text editor for code, markup and prose
+Exec=subl --file-forwarding com.sublimetext.three @@ %F @@
 Terminal=false
 MimeType=text/plain;
 Icon=com.sublimetext.three
@@ -15,8 +16,10 @@ X-Flatpak=com.sublimetext.three
 
 [Desktop Action Window]
 Name=New Window
+Exec=/opt/sublime_text/sublime_text com.sublimetext.three -n
 OnlyShowIn=Unity;
 
 [Desktop Action Document]
 Name=New File
+Exec=/opt/sublime_text/sublime_text com.sublimetext.three --command new_file
 OnlyShowIn=Unity;

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -2,7 +2,7 @@ app-id: com.sublimetext.three
 command: subl
 
 runtime: org.freedesktop.Sdk
-runtime-version: '25.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 
 separate-locales: false

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -2,7 +2,7 @@ app-id: com.sublimetext.three
 command: subl
 
 runtime: org.freedesktop.Sdk
-runtime-version: '21.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 
 separate-locales: false
@@ -11,7 +11,6 @@ finish-args:
   - --share=network
   - --device=dri
   - --socket=x11
-  - --socket=fallback-x11
   - --socket=wayland
   - --talk-name=org.gnome.SettingsDaemon
   - --filesystem=host
@@ -24,7 +23,7 @@ add-extensions:
     add-ld-path: lib
 
   com.sublimetext.three.DevUtils:
-    version: '21.08'
+    version: '25.08'
     directory: utils
     subdirectories: false
     add-ld-path: lib
@@ -72,12 +71,6 @@ modules:
         url: https://download.sublimetext.com/files/sublime-text_build-3211_amd64.deb
         sha256: 8b2c6dc1178b1f0aa861e76b21719747c1587482c014e12db10ca4424b539c34
         size: 9835156
-      - type: extra-data
-        only-arches: [i386]
-        filename: sublime.deb
-        url: https://download.sublimetext.com/files/sublime-text_build-3211_i386.deb
-        sha256: 8d94aa6755eb09400a5936865a2a948ef8c89c7e93f6346e8da32e06f6e1cd97
-        size: 10000308
       - type: extra-data
         filename: Package Control.sublime-package
         url: http://packagecontrol.io/Package%20Control.sublime-package

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -71,11 +71,6 @@ modules:
         url: https://download.sublimetext.com/files/sublime-text_build-3211_amd64.deb
         sha256: 8b2c6dc1178b1f0aa861e76b21719747c1587482c014e12db10ca4424b539c34
         size: 9835156
-      - type: extra-data
-        filename: Package Control.sublime-package
-        url: http://packagecontrol.io/Package%20Control.sublime-package
-        sha256: 817937144c34c84c88cd43b85318b2656f9c3fac02f8f72cbc18360b2c26d139
-        size: 471460
       - type: file
         path: com.sublimetext.three.desktop
       - type: file

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -2,7 +2,7 @@ app-id: com.sublimetext.three
 command: subl
 
 runtime: org.freedesktop.Sdk
-runtime-version: '25.08'
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 
 separate-locales: false
@@ -10,8 +10,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --device=dri
-  - --socket=fallback-x11
-  - --socket=wayland
+  - --socket=x11
   - --talk-name=org.gnome.SettingsDaemon
   - --filesystem=host
   - --env=PATH=/app/utils/bin:/app/sublime_merge/bin:/app/bin:/usr/bin
@@ -23,7 +22,7 @@ add-extensions:
     add-ld-path: lib
 
   com.sublimetext.three.DevUtils:
-    version: '25.08'
+    version: "25.08"
     directory: utils
     subdirectories: false
     add-ld-path: lib
@@ -39,38 +38,29 @@ modules:
         commands:
           - FLATPAK_ID=com.sublimetext.three
           # Extract upstream package
-          - mkdir -p deb-package export/share
-          - ar p sublime.deb data.tar.xz | tar -xJf - -C deb-package
+          - mkdir -p extract export/share
+          - tar -xJf sublime.tar.xz -C extract
           # Install desktop entry and icons
-          - mv deb-package/usr/share/{applications,icons} export/share/
+          - mv extract/usr/share/{applications,icons} export/share/
           - rename sublime_text ${FLATPAK_ID} export/share/applications/*.desktop
           - rename sublime-text ${FLATPAK_ID} export/share/icons/hicolor/*/apps/*
           - desktop-file-edit --set-key=Exec --set-value='subl %F' --set-key=Icon
             --set-value=${FLATPAK_ID} export/share/applications/${FLATPAK_ID}.desktop
           # Install the app
-          - mv deb-package/opt/sublime_text ./
+          - mv extract/opt/sublime_text ./
           - ln -sr /app/sublime_merge/extra/sublime_merge ./sublime_merge
           # Cleanup
-          - rm -rf deb-package sublime.deb
+          - rm -rf extract sublime.tar.xz
       - type: script
         dest-filename: subl
         commands:
-          - PCFILE="Package Control.sublime-package"
-          - PCLOCATION="$HOME/.var/app/com.sublimetext.three/config/sublime-text-3/Installed
-            Packages"
-          - |
-            if ! test -f "$PCLOCATION/$PCFILE"; then
-                mkdir -p "$PCLOCATION"
-                cp "/app/extra/$PCFILE" "$PCLOCATION"
-            fi
-          - export LC_NUMERIC=C
           - exec /app/extra/sublime_text/sublime_text --fwdargv0 "$0" "$@"
       - type: extra-data
         only-arches: [x86_64]
-        filename: sublime.deb
-        url: https://download.sublimetext.com/files/sublime-text_build-3211_amd64.deb
-        sha256: 8b2c6dc1178b1f0aa861e76b21719747c1587482c014e12db10ca4424b539c34
-        size: 9835156
+        filename: sublime.tar.xz
+        url: https://download.sublimetext.com/sublime-text-3211-1-x86_64.pkg.tar.xz
+        sha256: 874a7d79dc5193654a3a41cfb91ed6b8c10730879bf5705550503f154f52c932
+        size: 11305980
       - type: file
         path: com.sublimetext.three.desktop
       - type: file

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -10,7 +10,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --device=dri
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --talk-name=org.gnome.SettingsDaemon
   - --filesystem=host

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -2,7 +2,7 @@ app-id: com.sublimetext.three
 command: subl
 
 runtime: org.freedesktop.Sdk
-runtime-version: '21.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 
 separate-locales: false

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -2,7 +2,7 @@ app-id: com.sublimetext.three
 command: subl
 
 runtime: org.freedesktop.Sdk
-runtime-version: '23.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 
 separate-locales: false

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -10,7 +10,8 @@ finish-args:
   - --share=ipc
   - --share=network
   - --device=dri
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --talk-name=org.gnome.SettingsDaemon
   - --filesystem=host
   - --env=PATH=/app/utils/bin:/app/sublime_merge/bin:/app/bin:/usr/bin

--- a/com.sublimetext.three.yaml
+++ b/com.sublimetext.three.yaml
@@ -54,6 +54,7 @@ modules:
       - type: script
         dest-filename: subl
         commands:
+          - export LC_NUMERIC=C
           - exec /app/extra/sublime_text/sublime_text --fwdargv0 "$0" "$@"
       - type: extra-data
         only-arches: [x86_64]

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,5 @@
 {
-    "only-arches": ["x86_64", "i386"]
+    "only-arches": [
+        "x86_64"
+    ]
 }


### PR DESCRIPTION
Hi ^^

Well, this is my first flatpak PR, so feel free to correct what I've done - I don't use Sublime Text personally, but I know some people that do


Firstly, the Sublime Text flatpak is currently **really** outdated, and if no one is going to do something, then I may try.
This flatpak can be useful for people on distros that only ships flatpaks like Bluefin, Bazzite, the upcoming KDE Linux or even the SteamOS ! So Sublime Text needs to exist as a flatpak for at least these users. 

I know there has been an attempt a few years ago now, and I hope we can continue from where they left off. It's sad their pull request led to nothing. But if there's one or multiple people crazy enough to make it happen, it can be possible, and we can finally move forward.

With this in mind, this is what I've updated : 
-  the runtime version (#36)
-  the name and some infos of the app

This will get at least some confusion out of the way, like : this will be explicitly the flatpak for Sublime Text 3, an outdated version, and we know it; 
And we'll probably redirect the users towards the new flatpak once it's out there.


So you can call me stupid or inexperienced, because it's kind of true,
But I'm at least trying something out.


I'd be glad to hear you guys' feedback before adding these changes,
I hope it's a first step towards finally bringing Sublime Text 4 to Flathub !